### PR TITLE
第6章

### DIFF
--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "Projects", type: :system do
+  scenario "user creates a new project" do
+    user = FactoryBot.create(:user)
+
+    visit root_path
+    click_link "Sign in"
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_button "Log in"
+
+    expect {
+      click_link "New Project"
+      fill_in "Name", with: "Test Project"
+      fill_in "Description", with: "Trying out Capybara"
+      click_button "Create Project"
+
+      expect(page).to have_content "Project was successfully created"
+      expect(page).to have_content "Test Project"
+      expect(page).to have_content "Owner: #{user.name}"
+    }.to change(user.projects, :count).by(1)
+  end
+end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe "Tasks", type: :system do
+  scenario "user toggles a task", js: true do
+    user = FactoryBot.create(:user)
+    project = FactoryBot.create(:project,
+                                name: "RSpec tutorial",
+                                owner: user)
+    task = project.tasks.create!(name: "Finish RSpec tutorial")
+
+    visit root_path
+    click_link "Sign in"
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_button "Log in"
+
+    click_link "RSpec tutorial"
+    check "Finish RSpec tutorial"
+
+    expect(page).to have_css "label#task_#{task.id}.completed"
+    expect(task.reload).to be_completed
+
+    uncheck "Finish RSpec tutorial"
+
+    expect(page).to_not have_css "label#task_#{task.id}.completed"
+    expect(task.reload).to_not be_completed
+  end
+end


### PR DESCRIPTION
- フィーチャースペックよりもシステムスペックを使うことが推奨される
- フィーチャースペックとシステムスペックの違いと統合された理由
  - Rack::Testなどプロセス周りの兼ね合いで統合された
  - 同プロセスでDBからブラウザまでのテストを実行することができる