### PR TITLE
8章

### DIFF
--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -10,13 +10,11 @@ RSpec.describe ProjectsController, type: :controller do
       it "responds successfully" do
         sign_in @user
         get :index
-        expect(response).to be_successful
-      end
 
-      it "returns a 200 response" do
-        sign_in @user
-        get :index
-        expect(response).to have_http_status "200"
+        aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_http_status "200"
+        end
       end
     end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1,46 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
-  before do
-    @user = FactoryBot.create(:user)
-    @project = FactoryBot.create(:project, owner: @user)
-    @task = @project.tasks.create!(name: "Test task")
-  end
+  include_context "project setup"
 
   describe "#show" do
     it "responds with JSON formatted output" do
-      sign_in @user
+      sign_in user
       get :show, format: :json,
-          params: { project_id: @project.id, id: @task.id }
-      expect(response.content_type).to include "application/json"
+          params: { project_id: project.id, id: task.id }
+      expect(response).to have_content_type :json
     end
   end
 
   describe "#create" do
     it "responds with JSON formatted output" do
       new_task = { name: "New test task" }
-      sign_in @user
+      sign_in user
       post :create, format: :json,
-           params: { project_id: @project.id, task: new_task }
-      expect(response.content_type).to include "application/json"
+           params: { project_id: project.id, task: new_task }
+      expect(response).to have_content_type :json
     end
 
     it "adds a new task to the project" do
       new_task = { name: "New test task" }
-      sign_in @user
+      sign_in user
       expect {
         post :create, format: :json,
-             params: { project_id: @project.id, task: new_task }
-      }.to change(@project.tasks, :count).by(1)
+             params: { project_id: project.id, task: new_task }
+      }.to change(project.tasks, :count).by(1)
     end
 
     it "requires authentication" do
       new_task = { name: "New test task" }
-      # Don't sign in this time ...
       expect {
         post :create, format: :json,
-             params: { project_id: @project.id, task: new_task }
-      }.to_not change(@project.tasks, :count)
+             params: { project_id: project.id, task: new_task }
+      }.to_not change(project.tasks, :count)
       expect(response).to_not be_successful
     end
   end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,65 +1,60 @@
 require 'rails_helper'
 
 RSpec.describe Note, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) { FactoryBot.create(:project, owner: user) }
 
-  before do
-    @user = User.create(
-      first_name: "Joe",
-      last_name: "Tester",
-      email: "joetester@example.com",
-      password: "dottle-nouveau-pavilion-tights-furze"
-    )
+  it "is valid with a user, project, and message" do
+    note = Note.new(
+      message: "This is a sample note.",
+      user: user,
+      project: project,
+      )
+    expect(note).to be_valid
+  end
 
-    @project = @user.projects.create(
-      name: "Tester Project"
-    )
+  it "is invalid without a message" do
+    note = Note.new(message: nil)
+    note.valid?
+    expect(note.errors[:message]).to include("can't be blank")
   end
 
   describe "search message for a term" do
+    let!(:note1) {
+      FactoryBot.create(:note,
+                        project: project,
+                        user: user,
+                        message: "This is the first note.",
+                        )
+    }
 
-    it "is valid with a user, project, and message" do
-      note = Note.new(
-        message: "This is a sample note.",
-        user: @user,
-        project: @project
-      )
-      expect(note).to be_valid
+    let!(:note2) {
+      FactoryBot.create(:note,
+                        project: project,
+                        user: user,
+                        message: "This is the second note.",
+                        )
+    }
+
+    let!(:note3) {
+      FactoryBot.create(:note,
+                        project: project,
+                        user: user,
+                        message: "First, preheat the oven.",
+                        )
+    }
+
+    context "when a match is found" do
+      it "returns notes that match the search term" do
+        expect(Note.search("first")).to include(note1, note3)
+        expect(Note.search("first")).to_not include(note2)
+      end
     end
 
-    it "is invalid without a message" do
-      note = Note.new(message: nil)
-      note.valid?
-      expect(note.errors[:message]).to include("can't be blank")
-    end
-
-    describe "search message for a term" do
-      before do
-        @note1 = @project.notes.create(
-          message: "This is the first note.",
-          user: @user
-        )
-
-        @note2 = @project.notes.create(
-          message: "This is the second note.",
-          user: @user
-        )
-
-        @note3 = @project.notes.create(
-          message: "First, preheat the oven.",
-          user: @user
-        )
-      end
-
-      context "when a match is found" do
-        it "returns note that match the search term" do
-          expect(Note.search("first")).to include(@note1, @note3)
-        end
-      end
-
-      context "when no match is found" do
-        it "returns an empty collection" do
-          expect(Note.search("message")).to be_empty
-        end
+    context "when no match is found" do
+      it "returns an empty collection" do
+        expect(Note.search("message")).to be_empty
+        expect(Note.count).to eq 3
       end
     end
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  let(:project) { FactoryBot.create(:project) }
+
+  it "is valid with a project and name" do
+    task = Task.new(
+      project: project,
+      name: "Test task",
+      )
+    expect(task).to be_valid
+  end
+
+  it "is invalid without a project" do
+    task = Task.new(project: nil)
+    task.valid?
+    expect(task.errors[:project]).to include("must exist")
+  end
+
+  it "is invalid without a name" do
+    task = Task.new(name: nil)
+    task.valid?
+    expect(task.errors[:name]).to include("can't be blank")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,4 +64,5 @@ RSpec.configure do |config|
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include RequestSpecHelper, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/support/contexts/project_setup.rb
+++ b/spec/support/contexts/project_setup.rb
@@ -1,0 +1,5 @@
+RSpec.shared_context "project setup" do
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) { FactoryBot.create(:project, owner: user) }
+  let(:task) { project.tasks.create!(name: "Test task") }
+end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,0 +1,13 @@
+module LoginSupport
+  def sign_in_as(user)
+    visit root_path
+    click_link "Sign in"
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_button "Log in"
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/spec/support/matchers/content_type.rb
+++ b/spec/support/matchers/content_type.rb
@@ -1,0 +1,31 @@
+RSpec::Matchers.define :have_content_type do |expected|
+  match do |actual|
+    begin
+      actual.content_type.include? content_type(expected)
+    rescue ArgumentError
+      false
+    end
+  end
+
+  failure_message do |actual|
+    "Expected \"#{content_type(actual.content_type)} " +
+      "(#{actual.content_type})\" to be Content Type " +
+      "\"#{content_type(expected)}\" (#{expected})"
+  end
+
+  failure_message_when_negated do |actual|
+    "Expected \"#{content_type(actual.content_type)} " +
+      "(#{actual.content_type})\" to not be Content Type " +
+      "\"#{content_type(expected)}\" (#{expected})"
+  end
+
+  def content_type(type)
+    types = {
+      html: "text/html",
+      json: "application/json",
+    }
+    types[type.to_sym] || "unknown content type"
+  end
+end
+
+RSpec::Matchers.alias_matcher :be_content_type , :have_content_type

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -4,11 +4,9 @@ RSpec.describe "Projects", type: :system do
   scenario "user creates a new project" do
     user = FactoryBot.create(:user)
 
+    sign_in user
+
     visit root_path
-    click_link "Sign in"
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Log in"
 
     expect {
       click_link "New Project"
@@ -16,9 +14,11 @@ RSpec.describe "Projects", type: :system do
       fill_in "Description", with: "Trying out Capybara"
       click_button "Create Project"
 
-      expect(page).to have_content "Project was successfully created"
-      expect(page).to have_content "Test Project"
-      expect(page).to have_content "Owner: #{user.name}"
+      aggregate_failures do
+        expect(page).to have_content "Project was successfully created"
+        expect(page).to have_content "Test Project"
+        expect(page).to have_content "Owner: #{user.name}"
+      end
     }.to change(user.projects, :count).by(1)
   end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,28 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) {
+    FactoryBot.create(:project,
+                      name: "RSpec tutorial",
+                      owner: user)
+  }
+  let!(:task) { project.tasks.create!(name: "Finish RSpec tutorial") }
+
   scenario "user toggles a task", js: true do
-    user = FactoryBot.create(:user)
-    project = FactoryBot.create(:project,
-                                name: "RSpec tutorial",
-                                owner: user)
-    task = project.tasks.create!(name: "Finish RSpec tutorial")
+    sign_in user
+    go_to_project "RSpec tutorial"
 
+    complete_task "Finish RSpec tutorial"
+    expect_complete_task "Finish RSpec tutorial"
+
+    undo_complete_task "Finish RSpec tutorial"
+    expect_incomplete_task "Finish RSpec tutorial"
+  end
+
+  def go_to_project(name)
     visit root_path
-    click_link "Sign in"
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Log in"
+    click_link name
+  end
 
-    click_link "RSpec tutorial"
-    check "Finish RSpec tutorial"
+  def complete_task(name)
+    check name
+  end
 
-    expect(page).to have_css "label#task_#{task.id}.completed"
-    expect(task.reload).to be_completed
+  def undo_complete_task(name)
+    uncheck name
+  end
 
-    uncheck "Finish RSpec tutorial"
+  def expect_complete_task(name)
+    aggregate_failures do
+      expect(page).to have_css "label.completed", text: name
+      expect(task.reload).to be_completed
+    end
+  end
 
-    expect(page).to_not have_css "label#task_#{task.id}.completed"
-    expect(task.reload).to_not be_completed
+  def expect_incomplete_task(name)
+    aggregate_failures do
+      expect(page).to_not have_css "label.completed", text: name
+      expect(task.reload).to_not be_completed
+    end
   end
 end


### PR DESCRIPTION
- DRYの塩梅
- サポートモジュール
  - 共通のヘルパーメソッドを定義して使用する
  - サポートモジュールの呼び出しには、個別にincludeするか、全体にincludeしておくか分かれる
  - 個々のユースケースで行う認証処理などはテスト実施のための手順であり、テスト対象からすると重要な機能ではない
- let 
  - rubocop(rspec)ではlet!は非推奨となっている、before + インスタンス変数で
    - 本書でも見通しがよくない場合はbefore + インスタンス変数を使う方法が上げられている
    - ここは派閥がありそうなので、プロジェクト毎に決めるとよさそう
- shred_context
  - 多用しすぎない
- カスタムマッチャ
- aggregate_failures
  - mutationsのテストで使うとよさそう
  - https://qiita.com/jnchito/items/3a590480ee291a70027c